### PR TITLE
modify the flow to not default to our integration test project

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ We test the contents of our docs via [`testbook`](https://github.com/nteract/tes
 and pytest. These tests stand up live cloud infrastructure in our integration
 test project or `PROJECT_ID` if specified instead. The test suite relies on an
 active set of GCP credentials in your shell session so
-`gcloud auth login --update-adc` prior to running.
+`gcloud auth login --update-adc` prior to running. The currently set `PROJECT_ID`
+or `gcloud`-configured project will be used as the target for creating infra.
 
 Tests can be run via:
 
@@ -100,8 +101,8 @@ Tests can be run via:
 make test
 ```
 
-Optionally, you can specify the branch of `substratusai/substratus` to test
-against for all manifests referencing examples in that repo.
+Optionally, you can specify a remote branch of the `substratusai/substratus`
+repo to test against for all manifests referencing examples in that repo.
 
 ```bash
 make test SUBSTRATUS_BRANCH=feat/foobar

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -28,15 +28,15 @@ def ensure_gcp_project() -> str:
         capture_output=True,
         text=True,
     ).stdout.strip()
-    if project_id and project_id != "(unset)":
-        return f"gcloud config set project {project_id} -q"
 
-    project_id = os.environ.get("PROJECT_ID")
+    if project_id == "(unset)":
+        project_id = os.environ.get("PROJECT_ID")
+
     if not project_id:
         raise ValueError(
             "Project ID is not set. Please set the PROJECT_ID environment variable."
         )
-    return f"gcloud config set project {project_id} -q"
+    return f"!gcloud config set project {project_id} -q"
 
 
 @pytest.fixture(scope="session")

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,7 +1,8 @@
 import os
+import subprocess
 
 import pytest
-from pytest_dependency import depends  # import the depends function
+from pytest_dependency import depends
 from testbook import testbook
 from google.cloud import storage
 import google.auth
@@ -21,9 +22,21 @@ def authenticate_to_gcp():
         raise ValueError("credentials.token is empty")
 
 
-def ensure_gcp_project():
-    project_id = os.environ.get("PROJECT_ID", "substratus-integration-tests")
-    return f"!gcloud config set project {project_id} -q"
+def ensure_gcp_project() -> str:
+    project_id = subprocess.run(
+        ["gcloud", "config", "get-value", "project"],
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if project_id and project_id != "(unset)":
+        return f"gcloud config set project {project_id} -q"
+
+    project_id = os.environ.get("PROJECT_ID")
+    if not project_id:
+        raise ValueError(
+            "Project ID is not set. Please set the PROJECT_ID environment variable."
+        )
+    return f"gcloud config set project {project_id} -q"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
We don't want to be prescriptive about what project tests run against. This approach is friendlier to an outside contributor.